### PR TITLE
Improve PHPUnit fixtures and assertions

### DIFF
--- a/tests/Unit/Formatter/SlackLongAttachmentFormatterTest.php
+++ b/tests/Unit/Formatter/SlackLongAttachmentFormatterTest.php
@@ -18,7 +18,7 @@ final class SlackLongAttachmentFormatterTest extends TestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
@@ -122,7 +122,7 @@ final class SlackLongAttachmentFormatterTest extends TestCase
 
         $this->assertArrayHasKey('attachments', $data);
         $this->assertArrayHasKey(0, $data['attachments']);
-        $this->assertInternalType('array', $data['attachments'][0]);
+        $this->assertIsArray($data['attachments'][0]);
     }
 
     public function testAddsFallbackAndTextToAttachment()

--- a/tests/Unit/Formatter/SlackShortAttachmentFormatterTest.php
+++ b/tests/Unit/Formatter/SlackShortAttachmentFormatterTest.php
@@ -15,7 +15,7 @@ final class SlackShortAttachmentFormatterTest extends TestCase
      */
     private $jsonFlags;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
@@ -101,7 +101,7 @@ final class SlackShortAttachmentFormatterTest extends TestCase
 
         $this->assertArrayHasKey('attachments', $data);
         $this->assertArrayHasKey(0, $data['attachments']);
-        $this->assertInternalType('array', $data['attachments'][0]);
+        $this->assertIsArray($data['attachments'][0]);
     }
 
     public function testAddsFallbackAndTextToAttachment()

--- a/tests/Unit/Handler/SlackWebhookHandlerTest.php
+++ b/tests/Unit/Handler/SlackWebhookHandlerTest.php
@@ -37,7 +37,7 @@ final class SlackWebhookHandlerTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = $this->createMock(ClientInterface::class);


### PR DESCRIPTION
# Changed log

- According to the official [PHPunit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html?highlight=fixtures), it should be `protected function setUp(): void`.
- Using the `assertIsArray` to assert expected type is `array`.